### PR TITLE
copy_dashboard function variable dup_dashboard_id

### DIFF
--- a/metabase_api/metabase_api.py
+++ b/metabase_api/metabase_api.py
@@ -808,7 +808,7 @@ class Metabase_API():
         except TypeError: 
             # This error happens when res returns false, with a 503 error, when using an Heroku instance.
             # However the dashboard was created. We just need to pick the new dashboard id.
-            sleep(1)
+            sleep(3)
             dashboards = self.get("/api/dashboard/")
             dup_dashboard_id = sorted([x for x in dashboards if x['name'] == destination_dashboard_name], key=lambda k: k['created_at'], reverse=True)[0]['id']
 

--- a/metabase_api/metabase_api.py
+++ b/metabase_api/metabase_api.py
@@ -1,5 +1,6 @@
 import requests
 import getpass
+from time import sleep
 
 class Metabase_API():
 
@@ -801,7 +802,15 @@ class Metabase_API():
         ### shallow-copy
         shallow_copy_json = {'collection_id':destination_collection_id, 'name':destination_dashboard_name}
         res = self.post('/api/dashboard/{}/copy'.format(source_dashboard_id), json=shallow_copy_json)
-        dup_dashboard_id = res['id']
+        
+        try:
+            dup_dashboard_id = res['id']
+        except TypeError: 
+            # This error happens when res returns false, with a 503 error, when using an Heroku instance.
+            # However the dashboard was created. We just need to pick the new dashboard id.
+            sleep(1)
+            dashboards = self.get("/api/dashboard/")
+            dup_dashboard_id = sorted([x for x in dashboards if x['name'] == destination_dashboard_name], key=lambda k: k['created_at'], reverse=True)[0]['id']
 
         ### deepcopy
         if deepcopy:


### PR DESCRIPTION
This error happens when res returns false, with a 503 error, when using an Heroku instance.  It will depend on the number and size of Heroku dynos. In my case this issue happened if the Dashboard contained more than 24 cards/questions. However the dashboard was created. We just need to pick the new dashboard id.